### PR TITLE
refactor transcript logging functions for clarity and efficiency

### DIFF
--- a/garrysmod_addon/auris/lua/whisper/server/sv_whisper_log.lua
+++ b/garrysmod_addon/auris/lua/whisper/server/sv_whisper_log.lua
@@ -3,30 +3,25 @@ local function formatTimestamp()
     return os.date("[%H:%M:%S]")
 end
 
-local function getPlayerBySteamID64(sid)
-    for _, ply in ipairs(player.GetAll()) do
-        if ply:SteamID64() == sid then return ply end
-    end
-    return nil
-end
-
 local function writeTranscript(sid, text)
-    local ply = getPlayerBySteamID64(sid)
+    local ply = player.GetBySteamID64(sid)
     local name = IsValid(ply) and ply:Nick() or "Unknown"
-    local steamid = IsValid(ply) and ply:SteamID() or sid
-    local line = formatTimestamp() .. " " .. name
-    line = line .. " (" .. steamid .. "): " .. text .. "\n"
+    local line = ("%s %s (%s): %s\n"):format(formatTimestamp(), name, sid, text)
 
     file.Append("whisper/transcript.txt", line)
     print("[Whisper] " .. name .. ": " .. text)
 end
 
-timer.Create("Whisper_Poll", 0.1, 0, function()
-    local sid, text = whisper.Poll()
-    while sid do
-        writeTranscript(sid, text)
-        sid, text = whisper.Poll()
-    end
-end)
+if whisper.IsDebug() then
+    timer.Create("Whisper_Poll", 0.1, 0, function()
+        if not whisper.IsDebug() then return end
+
+        local sid, text = whisper.Poll()
+        while sid do
+            writeTranscript(sid, text)
+            sid, text = whisper.Poll()
+        end
+    end)
+end
 
 whisper.Debug(true)

--- a/garrysmod_addon/auris/lua/whisper/server/sv_whisper_log.lua
+++ b/garrysmod_addon/auris/lua/whisper/server/sv_whisper_log.lua
@@ -1,4 +1,6 @@
 -- Poll whisper for transcriptions and log them
+if not whisper.IsDebug() then return end
+
 local function formatTimestamp()
     return os.date("[%H:%M:%S]")
 end
@@ -12,16 +14,14 @@ local function writeTranscript(sid, text)
     print("[Whisper] " .. name .. ": " .. text)
 end
 
-if whisper.IsDebug() then
-    timer.Create("Whisper_Poll", 0.1, 0, function()
-        if not whisper.IsDebug() then return end
+timer.Create("Whisper_Poll", 0.1, 0, function()
+    if not whisper.IsDebug() then return end
 
-        local sid, text = whisper.Poll()
-        while sid do
-            writeTranscript(sid, text)
-            sid, text = whisper.Poll()
-        end
-    end)
-end
+    local sid, text = whisper.Poll()
+    while sid do
+        writeTranscript(sid, text)
+        sid, text = whisper.Poll()
+    end
+end)
 
 whisper.Debug(true)


### PR DESCRIPTION
I think it would be better if the logs were set to "debug" mode only. The people who manage the server don't need that kind of information.

Even if it's for "monitoring" purposes, that isn't the addon's main purpose.